### PR TITLE
Add autoconf check for dlopen linker options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ case "$host_os" in
 		CPPFLAGS="$CPPFLAGS -DLUA_USE_LINUX"
 		;;
 	darwin*)
-		dnl We have a problem here: both MacOS X and Darwin report 
+		dnl We have a problem here: both MacOS X and Darwin report
 		dnl the same signature "powerpc-apple-darwin*" - so we have
 		dnl to do more to distinguish them. Plain Darwin will propably
 		dnl use X-Windows; and it is of course lacking Cocoa.
@@ -47,6 +47,9 @@ AM_PATH_SDL($SDL_VERSION,
 )
 AC_LANG_CPLUSPLUS
 
+AC_SEARCH_LIBS([dlopen], [dl dld], [], [
+  AC_MSG_ERROR([unable to find the dlopen() function])
+])
 
 # debugging
 DEBUG_FLAGS="-O2"


### PR DESCRIPTION
This fixes the build process on Raspbian (and does not break it in Linux ;-).. well this autoconf check is pretty standard, so it should be safe).

Closes #36 