### PR TITLE
Fix include for case sensitive OSX file systems 

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -38,7 +38,7 @@
 
 #ifdef MACOSX
 #include <CoreFoundation/CoreFoundation.h>
-#include <xcodebuild/main.cpp>
+#include <XCodeBuild/main.cpp>
 int nuvieMain(int argc, char **argv)
 #else
 int main(int argc, char **argv)


### PR DESCRIPTION
This turned out to be a really easy fix. Now compiles cleanly on my case sensitive filesystem.

Closes #39 