### PR TITLE
Source changes for Visual Studio 2017 port

### DIFF
--- a/MsgScroll.cpp
+++ b/MsgScroll.cpp
@@ -493,9 +493,10 @@ bool MsgScroll::can_fit_token_on_msgline(MsgLine *msg_line, MsgText *token)
 
 bool MsgScroll::parse_token(MsgText *token)
 {
- MsgLine *msg_line;
+ MsgLine *msg_line = NULL;
 
- msg_line = msg_buf.back(); // retrieve the last line from the scroll buffer.
+ if (!msg_buf.empty())
+   msg_line = msg_buf.back(); // retrieve the last line from the scroll buffer.
 
  switch(token->s[0])
    {

--- a/script/ScriptCutscene.cpp
+++ b/script/ScriptCutscene.cpp
@@ -1112,7 +1112,7 @@ static int nscript_input_poll(lua_State *L)
 			if((((key.mod & KMOD_CAPS) == KMOD_CAPS && (key.mod & KMOD_SHIFT) == 0) || ((key.mod & KMOD_CAPS) == 0 && (key.mod & KMOD_SHIFT)))
 			   && key.sym >= SDLK_a && key.sym <= SDLK_z)
 				key.sym = (SDL_Keycode)(key.sym -32);
-			if(!isprint((char)key.sym) || (key.mod &KMOD_ALT) || (key.mod &KMOD_CTRL)|| (key.mod &KMOD_GUI))
+			if(key.sym > 0xFF || !isprint((char)key.sym) || (key.mod &KMOD_ALT) || (key.mod &KMOD_CTRL)|| (key.mod &KMOD_GUI))
 			{
 				ActionType a = keybinder->get_ActionType(key);
 				switch(keybinder->GetActionKeyType(a))


### PR DESCRIPTION
I have a few code changes as well, in order to run Nuvie in Visual Studio 2017.

- The change in MsgScroll.cpp is straight forward and happened to me once when starting a new game. 
- The change in ScriptCutscene.cpp occured when creating a new character in U6. It seems that Visual C++ asserts when key.sym has a value greater than 0xFF. I assumed the "if expression" is checking for non-printable keys or keys pressed together with modifier keys. I added the "key.sym > 0xFF" expression first, so that all non-printable SDL keys automatically give "true", and isprint() is never evaluated. I hope this change is correct for what you want to accomplish with this if expression here.
