### PR TITLE
Apply workaround for issue #54 and potential crash fix.

### DIFF
--- a/MsgScroll.cpp
+++ b/MsgScroll.cpp
@@ -493,10 +493,7 @@ bool MsgScroll::can_fit_token_on_msgline(MsgLine *msg_line, MsgText *token)
 
 bool MsgScroll::parse_token(MsgText *token)
 {
- MsgLine *msg_line = NULL;
-
- if(msg_buf.size() >0)
-	 msg_line = msg_buf.back(); // retrieve the last line from the scroll buffer.
+ MsgLine *msg_line;
 
  switch(token->s[0])
    {

--- a/MsgScroll.cpp
+++ b/MsgScroll.cpp
@@ -493,9 +493,10 @@ bool MsgScroll::can_fit_token_on_msgline(MsgLine *msg_line, MsgText *token)
 
 bool MsgScroll::parse_token(MsgText *token)
 {
- MsgLine *msg_line;
+ MsgLine *msg_line = NULL;
 
- msg_line = msg_buf.back(); // retrieve the last line from the scroll buffer.
+ if(msg_buf.size() >0)
+	 msg_line = msg_buf.back(); // retrieve the last line from the scroll buffer.
 
  switch(token->s[0])
    {

--- a/U6objects.h
+++ b/U6objects.h
@@ -210,6 +210,7 @@
 #define OBJ_U6_MOUSEHOLE           213
 #define OBJ_U6_CANNON              221
 #define OBJ_U6_POWDER_KEG          223
+#define OBJ_U6_THREAD              225
 #define OBJ_U6_WELL                233
 #define OBJ_U6_FOUNTAIN            234
 #define OBJ_U6_SUNDIAL             235

--- a/actors/Actor.cpp
+++ b/actors/Actor.cpp
@@ -839,8 +839,13 @@ uint32 Actor::inventory_count_object(uint16 obj_n)
     for(link = inv->start(); link != NULL; link = link->next)
     {
         obj = (Obj *)link->data;
-        if(obj)
-          qty += obj->get_total_qty(obj_n);
+		if (obj) {
+			uint32 obj_qty = obj->get_total_qty(obj_n); // FIXME: should this be returning 0? (issue #54)
+			if (obj_qty > 0)
+				qty += obj_qty;
+			else if(obj->obj_n == obj_n)
+				qty += 1;
+		}
     }
 
     return(qty);


### PR DESCRIPTION
…always return at least 1 for objects with qty=0. Fix for possible crash in MsgScroll::parse_token(). Check msg_buf size before returning. Add thread to U6Objects.