### PR TITLE
U6: Support for custom WAV songs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,6 +457,8 @@ set(SOURCE_FILES
     sound/Song.h
     sound/SongAdPlug.cpp
     sound/SongAdPlug.h
+    sound/SongCustom.cpp
+    sound/SongCustom.h
     sound/Sound.h
     sound/SoundManager.cpp
     sound/SoundManager.h

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2020-01-29 Michael C. Maggio <mcmaggio at mcmagi.com>
+	* Added support for playback of custom WAV songs
+
 2019-09-03 Mikey Alexander <firesword14 at yahoo.com>
         * Added support for Savage Empire "Tile Objects" (Use a map tile trees & yucca plant implemented)
         * Initial Savage Empire endgame scene

--- a/Makefile.common
+++ b/Makefile.common
@@ -257,6 +257,8 @@ nuvie_SOURCES = \
 	sound/Song.h \
 	sound/SongAdPlug.cpp \
 	sound/SongAdPlug.h \
+	sound/SongCustom.cpp \
+	sound/SongCustom.h \
 	sound/Sound.h \
 	sound/SoundManager.cpp \
 	sound/SoundManager.h \

--- a/data/scripts/u6/ending.lua
+++ b/data/scripts/u6/ending.lua
@@ -58,7 +58,7 @@ local function play()
 	canvas_set_opacity(0xff);
 	mouse_cursor_visible(false)
 	g_img_tbl = image_load_all("end.shp")
-	music_play("brit.m")
+	music_play_from("end_brit")
 --[ [
 	canvas_set_palette("endpal.lbm", 0)
 	canvas_set_update_interval(25)
@@ -218,7 +218,7 @@ local function play()
 	
 	update_star_field_and_wait()
 	
-	music_play("gargoyle.m")
+	music_play_from("end_gargoyle")
 	scroll_img = image_load("end.shp", 0xb)
 	image_print(scroll_img, "And waves of heat shimmer in the air, heralding the birth of another red gate!", 8, 303, 7, 9, 0x3e)
 	scroll.image = scroll_img
@@ -303,7 +303,7 @@ local function play()
 
 	update_star_field_and_wait()
 	
-	music_play("end.m")
+	music_play_from("end")
 	scroll_img = image_load("end.shp", 0xa)
 	image_print(scroll_img, "The ancient book opens. Both kings gaze upon its pages in spellbound silence, as the eloquence of Ultimate Wisdom is revealed in the tongues of each lord's domain. You, too, can read the answers the Codex gives...", 8, 303, 7, 13, 0x3e)
 	scroll.image = scroll_img

--- a/data/scripts/u6/intro.lua
+++ b/data/scripts/u6/intro.lua
@@ -1030,7 +1030,7 @@ local function play()
 mouse_cursor_set_pointer(0)
 mouse_cursor_visible(false)
 load_images("intro_1.shp")
-music_play("bootup.m")
+music_play_from("bootup")
 --[ [
 canvas_set_palette("palettes.int", 0)
 canvas_set_update_interval(25)
@@ -1044,7 +1044,7 @@ background.y = 0
 background.opacity = 0
 background.visible = true
 
-music_play("bootup.m")
+music_play_from("bootup")
 for i=0,0xff,3 do
 	background.opacity = i
 	if poll_for_esc() == true then return end
@@ -1678,7 +1678,7 @@ g_keycode_tbl =
 [122]="z",
 }
 local function create_character()
-	music_play("create.m")
+	music_play_from("create")
 	
 	local bubbles = sprite_new(image_new(100,100, 0), 110, 30, false)
 	local bg = sprite_new(image_load("vellum1.shp", 0), 0x10, 0x50, true)
@@ -2340,7 +2340,7 @@ local function intro()
 	local ropes = sprite_new(intro_img_tbl[12], 0xd2, 0x84, false)
 			
 	canvas_set_palette("palettes.int", 7)
-	music_play("intro.m")
+	music_play_from("intro")
 					
 	fade_in()
 	
@@ -2953,7 +2953,7 @@ local function main_menu_set_pal(idx)
 end
 
 local function main_menu_load()
-	music_play("ultima.m")
+	music_play_from("menu")
 	g_menu = {}
 	
 	canvas_set_palette("palettes.int", 0)
@@ -2981,7 +2981,7 @@ local function selected_intro()
 	fade_out()
 	canvas_hide_all_sprites()
 	intro()
-	music_play("ultima.m")
+	music_play_from("menu")
 	g_menu["title"].visible = true
 	fade_in()
 	g_menu["subtitle"].visible = true
@@ -3000,7 +3000,7 @@ local function selected_create_character()
 	canvas_set_palette("palettes.int", 0)
 	g_menu_idx=0
 	main_menu_set_pal(g_menu_idx)
-	music_play("ultima.m")
+	music_play_from("menu")
 	fade_in_sprite(g_menu["menu"])
 	return false
 end
@@ -3063,21 +3063,7 @@ local function main_menu()
 					input = input - 48
 				end
 
-				local song_names = {
-					"ultima.m",
-					"bootup.m",
-					"intro.m",
-					"create.m",
-					"forest.m",
-					"hornpipe.m",
-					"engage.m",
-					"stones.m",
-					"dungeon.m",
-					"brit.m",
-					"gargoyle.m",
-					"end.m"
-				}
-				music_play(song_names[input])
+				music_play_songnum(input)
 			elseif input == 0 then --mouse click
 				local x = get_mouse_x()
 				if x > 56 and x < 264 then

--- a/script/ScriptCutscene.cpp
+++ b/script/ScriptCutscene.cpp
@@ -113,6 +113,8 @@ static int nscript_canvas_string_length(lua_State *L);
 static int nscript_canvas_rotate_game_palette(lua_State *L);
 
 static int nscript_music_play(lua_State *L);
+static int nscript_music_play_from(lua_State *L);
+static int nscript_music_play_songnum(lua_State *L);
 static int nscript_music_stop(lua_State *L);
 static int nscript_get_mouse_x(lua_State *L);
 static int nscript_get_mouse_y(lua_State *L);
@@ -222,6 +224,12 @@ void nscript_init_cutscene(lua_State *L, Configuration *cfg, GUI *gui, SoundMana
 
    lua_pushcfunction(L, nscript_music_play);
    lua_setglobal(L, "music_play");
+
+   lua_pushcfunction(L, nscript_music_play_from);
+   lua_setglobal(L, "music_play_from");
+
+   lua_pushcfunction(L, nscript_music_play_songnum);
+   lua_setglobal(L, "music_play_songnum");
 
    lua_pushcfunction(L, nscript_music_stop);
    lua_setglobal(L, "music_stop");
@@ -1056,6 +1064,24 @@ static int nscript_music_play(lua_State *L)
 	}
 
 	cutScene->get_sound_manager()->musicPlay(filename, song_num);
+
+	return 0;
+}
+
+static int nscript_music_play_from(lua_State *L)
+{
+	const char *groupname = lua_tostring(L, 1);
+
+	cutScene->get_sound_manager()->musicPlayFrom(groupname);
+
+	return 0;
+}
+
+static int nscript_music_play_songnum(lua_State *L)
+{
+	uint16 song_num = lua_tointeger(L, 1);
+
+	cutScene->get_sound_manager()->musicPlaySongnum(song_num);
 
 	return 0;
 }

--- a/sound/SongCustom.cpp
+++ b/sound/SongCustom.cpp
@@ -1,0 +1,93 @@
+/*
+ *  SongCustom.cpp
+ *  Nuvie
+ *
+ *  Created by Eric Fry on Wed Feb 11 2004.
+ *  Copyright (c) 2004. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+//Mix_HookMusicFinished
+
+#include "nuvieDefs.h"
+#include "adplug/emuopl.h"
+#include "adplug/u6m.h"
+#include "decoder/wave/stdiostream.h"
+
+#include "SongCustom.h"
+#include "SoundManager.h"
+
+SongCustom::SongCustom(Audio::Mixer *m) : mixer(m) {
+ samples_left = 0;
+ stream = NULL;
+}
+
+SongCustom::~SongCustom() {
+ //delete player;
+}
+
+bool SongCustom::Init(const char *filename) {
+    if(filename == NULL)
+      return false;
+
+    m_Filename = filename; // SB-X
+
+	Common::SeekableReadStream *readStream = StdioStream::makeFromPath(filename);
+	if(readStream == NULL)
+	{
+		DEBUG(0, LEVEL_ERROR, "Failed to open '%s'", filename);
+		return false;
+	}
+
+	stream = Audio::makeWAVStream(readStream, DisposeAfterUse::YES);
+
+    return true;
+}
+
+bool SongCustom::Play(bool looping) {
+
+    if(stream)
+    {
+    	mixer->playStream(Audio::Mixer::kMusicSoundType, &handle, (Audio::AudioStream *) stream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO);
+    }
+	return true;
+}
+
+bool SongCustom::Stop() {
+
+	mixer->stopHandle(handle);
+	stream->rewind();
+    return true;
+}
+
+bool SongCustom::SetVolume(uint8 volume)
+{
+	mixer->setChannelVolume(handle, volume);
+	return true;
+}
+
+/*
+bool SongCustom::Pause() {
+	if (!Mix_PlayingMusic()) return false;
+	return true;
+}
+
+bool SongCustom::Resume() {
+	if (Mix_PlayingMusic()) return false;
+	return true;
+}
+*/

--- a/sound/SongCustom.cpp
+++ b/sound/SongCustom.cpp
@@ -60,10 +60,15 @@ bool SongCustom::Init(const char *filename) {
 
 bool SongCustom::Play(bool looping) {
 
-    if(stream)
-    {
-    	mixer->playStream(Audio::Mixer::kMusicSoundType, &handle, (Audio::AudioStream *) stream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO);
-    }
+	if(looping)
+	{
+		Audio::LoopingAudioStream *looping_stream = new Audio::LoopingAudioStream(stream, 0);
+		mixer->playStream(Audio::Mixer::kPlainSoundType, &handle, looping_stream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO);
+	}
+	else
+	{
+		mixer->playStream(Audio::Mixer::kPlainSoundType, &handle, (Audio::AudioStream *) stream, -1, Audio::Mixer::kMaxChannelVolume, 0, DisposeAfterUse::NO);
+	}
 	return true;
 }
 

--- a/sound/SongCustom.h
+++ b/sound/SongCustom.h
@@ -1,0 +1,50 @@
+/*
+ *  SongCustom.h
+ *  Nuvie
+ *
+ *  Created by Eric Fry on Wed Feb 11 2004.
+ *  Copyright (c) 2004. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+#ifndef __SongCustom_h__
+#define __SongCustom_h__
+
+#include "audiostream.h"
+#include "mixer.h"
+#include "decoder/wave/wave.h"
+#include "Song.h"
+
+class SongCustom : public Song {
+public:
+    uint16 samples_left;
+
+	SongCustom(Audio::Mixer *m);
+	~SongCustom();
+	bool Init(const char *filename);
+	bool Play(bool looping = false);
+	bool Stop();
+	bool SetVolume(uint8 volume);
+	bool FadeOut(float seconds) { return false; }
+
+private:
+    Audio::Mixer *mixer;
+    Audio::SoundHandle handle;
+	Audio::RewindableAudioStream *stream = NULL;
+
+};
+
+#endif /* __SongCustom_h__ */

--- a/sound/SoundManager.cpp
+++ b/sound/SoundManager.cpp
@@ -31,6 +31,7 @@
 #include "emuopl.h"
 #include "SoundManager.h"
 #include "SongAdPlug.h"
+#include "SongCustom.h"
 #include "Sample.h"
 #include <algorithm>
 #include <cmath>
@@ -304,7 +305,7 @@ bool SoundManager::LoadCustomSongs (string sound_dir)
       song = (Song *)SongExists(token2);
       if(song == NULL)
         {
-          song = new Song;
+          song = new SongCustom(mixer->getMixer());
           if(!loadSong(song, filename.c_str()))
             continue; //error loading song
         }

--- a/sound/SoundManager.cpp
+++ b/sound/SoundManager.cpp
@@ -752,7 +752,7 @@ void SoundManager::update()
       if(m_pCurrentSong)
         {
           DEBUG(0,LEVEL_INFORMATIONAL,"assigning new song! '%s'\n", m_pCurrentSong->GetName().c_str());
-          if(!m_pCurrentSong->Play (false))
+          if(!m_pCurrentSong->Play (true))
             {
               DEBUG(0,LEVEL_ERROR,"play failed!\n");
             }

--- a/sound/SoundManager.h
+++ b/sound/SoundManager.h
@@ -63,6 +63,7 @@ public:
     void update(); // at the moment this just changes songs if required
 
     void musicPlayFrom(string group);
+    void musicPlaySongnum(int songnum);
 
     void musicPause();
     void musicPlay();
@@ -107,6 +108,7 @@ private:
 	Sound* RequestTileSound(int id);
 	Sound* RequestObjectSound(int id);
 	Sound* RequestSong(string group); //request a song from this group
+	Sound* RequestSong(int songnum); // request a song by list index
 
 	uint16 RequestObjectSfxId(uint16 obj_n);
 


### PR DESCRIPTION
Added support for playback of custom songs with the intended goal of integrating MT-32 music. This consists of the following changes:
* Added class CustomSong which leverages the scummvm wav playback used for SFX.
* Load all native U6 songs upfront in SoundManager
* Play music by group or song number (rather than filename) when invoked from LUA scripts
* Enhanced parsing of music.cfg to support multiple groups and song names